### PR TITLE
Implement join/leave waitlist

### DIFF
--- a/app/src/main/java/ca/ualberta/codarc/codarc_events/models/Event.java
+++ b/app/src/main/java/ca/ualberta/codarc/codarc_events/models/Event.java
@@ -17,6 +17,8 @@ public class Event implements Serializable {
     private boolean open;
     private String organizerId;
     private String qrCode;
+    private Integer maxCapacity;
+    private String location;
 
     public Event() { }
 
@@ -46,6 +48,8 @@ public class Event implements Serializable {
     public String getOrganizerId() { return organizerId; }
 
     public String getQrCode() { return qrCode; }
+    public Integer getMaxCapacity() { return maxCapacity; }
+    public String getLocation() { return location; }
 
     // Setters
     public void setId(String id) { this.id = id; }
@@ -57,5 +61,7 @@ public class Event implements Serializable {
     public void setOpen(boolean open) { this.open = open; }
     public void setOrganizerId(String organizerId) { this.organizerId = organizerId; }
     public void setQrCode(String qrCode) { this.qrCode = qrCode; }
+    public void setMaxCapacity(Integer maxCapacity) { this.maxCapacity = maxCapacity; }
+    public void setLocation(String location) { this.location = location; }
 }
 

--- a/app/src/main/java/ca/ualberta/codarc/codarc_events/views/CreateEventActivity.java
+++ b/app/src/main/java/ca/ualberta/codarc/codarc_events/views/CreateEventActivity.java
@@ -31,7 +31,7 @@ import ca.ualberta.codarc.codarc_events.utils.Identity;
 public class CreateEventActivity extends AppCompatActivity {
 
     private TextInputEditText title, description, eventDateTime,
-            regOpen, regClose;
+            regOpen, regClose, location, capacity;
     private EventDB eventDB;
     private ProgressBar progressBar;
 
@@ -47,8 +47,10 @@ public class CreateEventActivity extends AppCompatActivity {
         title = findViewById(R.id.et_title);
         description = findViewById(R.id.et_description);
         eventDateTime = findViewById(R.id.et_datetime);
+        location = findViewById(R.id.et_location);
         regOpen = findViewById(R.id.et_reg_open);
         regClose = findViewById(R.id.et_reg_close);
+        capacity = findViewById(R.id.et_capacity);
 
         Button createButton = findViewById(R.id.btn_create_event);
         Button cancelButton = findViewById(R.id.btn_cancel);
@@ -117,8 +119,10 @@ public class CreateEventActivity extends AppCompatActivity {
         String name = get(title);
         String desc = get(description);
         String dateTime = getDateValue(eventDateTime);
+        String loc = get(location);
         String open = getDateValue(regOpen);
         String close = getDateValue(regClose);
+        String capacityStr = get(capacity);
 
         if (name.isEmpty() || dateTime.isEmpty() || open.isEmpty() || close.isEmpty()) {
             Toast.makeText(this, "Fill all required fields", Toast.LENGTH_SHORT).show();
@@ -127,18 +131,31 @@ public class CreateEventActivity extends AppCompatActivity {
 
         String id = UUID.randomUUID().toString();
         String organizerId = Identity.getOrCreateDeviceId(this);
-        String qrData = "event:" + id; // store QR data as a string
+        String qrData = "event:" + id;
 
         Event event = new Event();
         event.setId(id);
         event.setName(name);
         event.setDescription(desc);
         event.setEventDateTime(dateTime);
+        event.setLocation(loc);
         event.setRegistrationOpen(open);
         event.setRegistrationClose(close);
         event.setOrganizerId(organizerId);
         event.setQrCode(qrData);
         event.setOpen(true);
+
+        // Parse capacity (optional field)
+        if (capacityStr != null && !capacityStr.isEmpty()) {
+            try {
+                Integer maxCap = Integer.parseInt(capacityStr);
+                event.setMaxCapacity(maxCap > 0 ? maxCap : null);
+            } catch (NumberFormatException e) {
+                event.setMaxCapacity(null);
+            }
+        } else {
+            event.setMaxCapacity(null);
+        }
 
         progressBar.setVisibility(View.VISIBLE);
 

--- a/app/src/main/java/ca/ualberta/codarc/codarc_events/views/EventDetailsActivity.java
+++ b/app/src/main/java/ca/ualberta/codarc/codarc_events/views/EventDetailsActivity.java
@@ -4,15 +4,21 @@ import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.content.Intent;
 import android.util.Log;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import ca.ualberta.codarc.codarc_events.R;
 import ca.ualberta.codarc.codarc_events.data.EntrantDB;
+import ca.ualberta.codarc.codarc_events.data.EventDB;
 import ca.ualberta.codarc.codarc_events.models.Entrant;
 import ca.ualberta.codarc.codarc_events.models.Event;
 import ca.ualberta.codarc.codarc_events.utils.Identity;
@@ -25,6 +31,12 @@ import com.journeyapps.barcodescanner.BarcodeEncoder;
  */
 public class EventDetailsActivity extends AppCompatActivity {
 
+    private Event event;
+    private EventDB eventDB;
+    private MaterialButton joinBtn;
+    private MaterialButton leaveBtn;
+    private String deviceId;
+
     /**
      * Initializes the event details screen, populating UI from the Event passed via Intent.
      * Displays event information and regenerates the QR code from stored data.
@@ -36,15 +48,8 @@ public class EventDetailsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_event_detail);
 
-        // UI references
-        TextView title = findViewById(R.id.event_title);
-        TextView desc = findViewById(R.id.event_desc);
-        TextView dateTime = findViewById(R.id.event_datetime);
-        TextView regWindow = findViewById(R.id.event_reg_window);
-        ImageView qrImage = findViewById(R.id.event_qr);
-        MaterialButton joinBtn = findViewById(R.id.btn_join_waitlist);
-
-        Event event = (Event) getIntent().getSerializableExtra("event");
+        // Initialize fields
+        this.event = (Event) getIntent().getSerializableExtra("event");
         if (event == null) {
             Log.e("EventDetailsActivity", "Event not found in Intent");
             Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
@@ -52,16 +57,33 @@ public class EventDetailsActivity extends AppCompatActivity {
             return;
         }
 
+        this.eventDB = new EventDB();
+        this.deviceId = Identity.getOrCreateDeviceId(this);
+        this.joinBtn = findViewById(R.id.btn_join_waitlist);
+        this.leaveBtn = findViewById(R.id.btn_leave_waitlist);
+
+        // UI references
+        TextView title = findViewById(R.id.event_title);
+        TextView desc = findViewById(R.id.event_desc);
+        TextView dateTime = findViewById(R.id.event_datetime);
+        TextView regWindow = findViewById(R.id.event_reg_window);
+        ImageView qrImage = findViewById(R.id.event_qr);
+
         title.setText(event.getName());
         desc.setText(event.getDescription());
         dateTime.setText(event.getEventDateTime());
+        
+        TextView location = findViewById(R.id.event_location);
+        String eventLocation = event.getLocation();
+        location.setText("Location: " + (eventLocation != null && !eventLocation.isEmpty() ? eventLocation : "TBD"));
+        
         regWindow.setText("Registration: " + event.getRegistrationOpen() + " → " + event.getRegistrationClose());
 
         // Generate QR code with null safety
         try {
             String qrData = event.getQrCode();
             if (qrData == null || qrData.isEmpty()) {
-                qrData = "event:" + event.getId(); // Fallback to event ID
+                qrData = "event:" + event.getId();
                 Log.w("EventDetailsActivity", "QR code missing, using fallback: " + qrData);
             }
             BarcodeEncoder encoder = new BarcodeEncoder();
@@ -72,27 +94,280 @@ public class EventDetailsActivity extends AppCompatActivity {
             Toast.makeText(this, "Failed to display QR code", Toast.LENGTH_SHORT).show();
         }
 
-        joinBtn.setOnClickListener(v -> {
-            String deviceId = Identity.getOrCreateDeviceId(this);
-            EntrantDB entrantDB = new EntrantDB();
-            entrantDB.getProfile(deviceId, new EntrantDB.Callback<Entrant>() {
-                @Override
-                public void onSuccess(Entrant entrant) {
-                    boolean isRegistered = entrant != null && entrant.getIsRegistered();
-                    if (!isRegistered) {
+        // Initially hide leave button
+        leaveBtn.setVisibility(View.GONE);
+
+        // Set up button handlers
+        joinBtn.setOnClickListener(v -> showJoinConfirmation());
+        leaveBtn.setOnClickListener(v -> showLeaveConfirmation());
+
+        // Check waitlist status on load
+        checkWaitlistStatus();
+    }
+
+    /**
+     * Checks if current user is on the waitlist and updates UI accordingly.
+     */
+    private void checkWaitlistStatus() {
+        if (event == null || deviceId == null) {
+            return;
+        }
+
+        eventDB.isEntrantOnWaitlist(event.getId(), deviceId, new EventDB.Callback<Boolean>() {
+            @Override
+            public void onSuccess(Boolean isOnWaitlist) {
+                runOnUiThread(() -> updateButtonVisibility(isOnWaitlist));
+            }
+
+            @Override
+            public void onError(@NonNull Exception e) {
+                Log.e("EventDetailsActivity", "Failed to check waitlist status", e);
+                runOnUiThread(() -> updateButtonVisibility(false));
+            }
+        });
+    }
+
+    /**
+     * Updates button visibility based on waitlist status.
+     */
+    private void updateButtonVisibility(boolean isOnWaitlist) {
+        if (isOnWaitlist) {
+            joinBtn.setVisibility(View.GONE);
+            leaveBtn.setVisibility(View.VISIBLE);
+        } else {
+            joinBtn.setVisibility(View.VISIBLE);
+            leaveBtn.setVisibility(View.GONE);
+        }
+    }
+
+    /**
+     * Shows confirmation dialog for joining waitlist.
+     */
+    private void showJoinConfirmation() {
+        new AlertDialog.Builder(this)
+                .setTitle("Join Waitlist")
+                .setMessage("Are you sure you want to join the waitlist for this event?")
+                .setPositiveButton("Join", (dialog, which) -> performJoin())
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    /**
+     * Performs the join waitlist operation with validation.
+     */
+    private void performJoin() {
+        // Check profile registration first
+        EntrantDB entrantDB = new EntrantDB();
+        entrantDB.getProfile(deviceId, new EntrantDB.Callback<Entrant>() {
+            @Override
+            public void onSuccess(Entrant entrant) {
+                boolean isRegistered = entrant != null && entrant.getIsRegistered();
+                if (!isRegistered) {
+                    runOnUiThread(() -> {
                         Intent intent = new Intent(EventDetailsActivity.this, ProfileCreationActivity.class);
                         startActivity(intent);
+                    });
+                    return;
+                }
+
+                // Check if already joined
+                eventDB.isEntrantOnWaitlist(event.getId(), deviceId, new EventDB.Callback<Boolean>() {
+                    @Override
+                    public void onSuccess(Boolean alreadyJoined) {
+                        if (alreadyJoined) {
+                            runOnUiThread(() -> {
+                                Toast.makeText(EventDetailsActivity.this,
+                                        "Already joined", Toast.LENGTH_SHORT).show();
+                            });
+                            return;
+                        }
+
+                        // Validate conditions (registration window, capacity)
+                        validateJoinConditions(event,
+                                () -> {
+                                    // All validations passed, join waitlist
+                                    eventDB.joinWaitlist(event.getId(), deviceId, new EventDB.Callback<Void>() {
+                                        @Override
+                                        public void onSuccess(Void value) {
+                                            runOnUiThread(() -> {
+                                                Toast.makeText(EventDetailsActivity.this,
+                                                        "Joined successfully", Toast.LENGTH_SHORT).show();
+                                                checkWaitlistStatus();
+                                            });
+                                        }
+
+                                        @Override
+                                        public void onError(@NonNull Exception e) {
+                                            Log.e("EventDetailsActivity", "Failed to join waitlist", e);
+                                            runOnUiThread(() -> {
+                                                Toast.makeText(EventDetailsActivity.this,
+                                                        "Failed to join. Please try again.", Toast.LENGTH_SHORT).show();
+                                            });
+                                        }
+                                    });
+                                },
+                                () -> {
+                                    // Validation failed (error already shown)
+                                }
+                        );
+                    }
+
+                    @Override
+                    public void onError(@NonNull Exception e) {
+                        Log.e("EventDetailsActivity", "Failed to check join status", e);
+                        runOnUiThread(() -> {
+                            Toast.makeText(EventDetailsActivity.this,
+                                    "Failed to check status. Please try again.", Toast.LENGTH_SHORT).show();
+                        });
+                    }
+                });
+            }
+
+            @Override
+            public void onError(@NonNull Exception e) {
+                Log.e("EventDetailsActivity", "Failed to check profile", e);
+                runOnUiThread(() -> {
+                    Toast.makeText(EventDetailsActivity.this,
+                            "Failed to check profile", Toast.LENGTH_SHORT).show();
+                });
+            }
+        });
+    }
+
+    /**
+     * Shows confirmation dialog for leaving waitlist.
+     */
+    private void showLeaveConfirmation() {
+        new AlertDialog.Builder(this)
+                .setTitle("Leave Waitlist")
+                .setMessage("Are you sure you want to leave the waitlist for this event?")
+                .setPositiveButton("Leave", (dialog, which) -> performLeave())
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    /**
+     * Performs the leave waitlist operation.
+     */
+    private void performLeave() {
+        // Check if actually on waitlist
+        eventDB.isEntrantOnWaitlist(event.getId(), deviceId, new EventDB.Callback<Boolean>() {
+            @Override
+            public void onSuccess(Boolean isOnWaitlist) {
+                if (!isOnWaitlist) {
+                    runOnUiThread(() -> {
+                        Toast.makeText(EventDetailsActivity.this,
+                                "You are not registered for this event", Toast.LENGTH_SHORT).show();
+                    });
+                    return;
+                }
+
+                // Perform leave operation
+                eventDB.leaveWaitlist(event.getId(), deviceId, new EventDB.Callback<Void>() {
+                    @Override
+                    public void onSuccess(Void value) {
+                        runOnUiThread(() -> {
+                            Toast.makeText(EventDetailsActivity.this,
+                                    "You have left this event", Toast.LENGTH_SHORT).show();
+                            checkWaitlistStatus();
+                        });
+                    }
+
+                    @Override
+                    public void onError(@NonNull Exception e) {
+                        Log.e("EventDetailsActivity", "Failed to leave waitlist", e);
+                        runOnUiThread(() -> {
+                            Toast.makeText(EventDetailsActivity.this,
+                                    "Failed to leave. Please try again.", Toast.LENGTH_SHORT).show();
+                        });
+                    }
+                });
+            }
+
+            @Override
+            public void onError(@NonNull Exception e) {
+                Log.e("EventDetailsActivity", "Failed to check leave status", e);
+                runOnUiThread(() -> {
+                    Toast.makeText(EventDetailsActivity.this,
+                            "Failed to check status. Please try again.", Toast.LENGTH_SHORT).show();
+                });
+            }
+        });
+    }
+
+    /**
+     * Validates if current time is within the registration window.
+     */
+    private boolean isWithinRegistrationWindow(Event event) {
+        try {
+            SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+            long now = System.currentTimeMillis();
+
+            String regOpen = event.getRegistrationOpen();
+            String regClose = event.getRegistrationClose();
+
+            if (regOpen == null || regOpen.isEmpty() || regClose == null || regClose.isEmpty()) {
+                return false;
+            }
+
+            long openTime = isoFormat.parse(regOpen).getTime();
+            long closeTime = isoFormat.parse(regClose).getTime();
+
+            return now >= openTime && now <= closeTime;
+        } catch (java.text.ParseException e) {
+            Log.e("EventDetailsActivity", "Error parsing registration window", e);
+            return false;
+        } catch (Exception e) {
+            Log.e("EventDetailsActivity", "Unexpected error in registration window check", e);
+            return false;
+        }
+    }
+
+    /**
+     * Validates all conditions for joining:
+     * 1. Registration window is open
+     * 2. Capacity limit not reached (if set)
+     */
+    private void validateJoinConditions(Event event, Runnable onValid, Runnable onInvalid) {
+        // Check registration window
+        if (!isWithinRegistrationWindow(event)) {
+            runOnUiThread(() -> {
+                Toast.makeText(this, "Registration window is closed", Toast.LENGTH_SHORT).show();
+            });
+            if (onInvalid != null) onInvalid.run();
+            return;
+        }
+
+        // Check capacity (if maxCapacity is set)
+        Integer maxCapacity = event.getMaxCapacity();
+        if (maxCapacity != null && maxCapacity > 0) {
+            eventDB.getWaitlistCount(event.getId(), new EventDB.Callback<Integer>() {
+                @Override
+                public void onSuccess(Integer currentCount) {
+                    if (currentCount >= maxCapacity) {
+                        runOnUiThread(() -> {
+                            Toast.makeText(EventDetailsActivity.this,
+                                    "Event is full", Toast.LENGTH_SHORT).show();
+                        });
+                        if (onInvalid != null) onInvalid.run();
                     } else {
-                        Toast.makeText(EventDetailsActivity.this, "Ready to join (registered)", Toast.LENGTH_SHORT).show();
+                        if (onValid != null) onValid.run();
                     }
                 }
 
                 @Override
                 public void onError(@NonNull Exception e) {
-                    Log.e("EventDetailsActivity", "Failed to check profile", e);
-                    Toast.makeText(EventDetailsActivity.this, "Failed to check profile", Toast.LENGTH_SHORT).show();
+                    Log.e("EventDetailsActivity", "Failed to check capacity", e);
+                    runOnUiThread(() -> {
+                        Toast.makeText(EventDetailsActivity.this,
+                                "Failed to check availability", Toast.LENGTH_SHORT).show();
+                    });
+                    if (onInvalid != null) onInvalid.run();
                 }
             });
-        });
+        } else {
+            // No capacity limit, proceed
+            if (onValid != null) onValid.run();
+        }
     }
 }

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -66,6 +66,15 @@
             android:layout_height="wrap_content"
             android:text="Join Waitlist"
             android:layout_marginTop="24dp" />
+
+        <!-- Leave Waitlist button-->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_leave_waitlist"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Leave Waitlist"
+            android:layout_marginTop="8dp"
+            android:visibility="gone" />
     </LinearLayout>
 </ScrollView>
 


### PR DESCRIPTION
### PR description
Implements join and leave waitlist for entrants (US 01.01.01 & 01.01.02).
**Features:**

- Entrants can join/leave waitlists with confirmation dialogs
- Validation: registration window, capacity limits, duplicate prevention
- UI shows/hides Join/Leave buttons based on waitlist status
- Firestore structure: events/{eventId}/entrants/{deviceId} with is_waiting field

**Technical changes:**

- Added 5 waitlist methods to EventDB
- Refactored EventDetailsActivity with validation and status checking
- Added maxCapacity and location fields to Event model
- Bug fix: Event IDs now set in getAllEvents()

**Acceptance criteria:**

- Join/Leave buttons with confirmation dialogs
- Success/error messages per acceptance criteria
- Validation prevents invalid joins
- Idempotent operations